### PR TITLE
Keep GitHub Actions from stopping

### DIFF
--- a/.github/workflows/action-keepalive.yml
+++ b/.github/workflows/action-keepalive.yml
@@ -1,0 +1,16 @@
+name: Keep GitHub Actions Alive... Because raisins
+on:
+  schedule:
+    - cron: 45 23 1 * *
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch origin actions
+          git checkout actions
+          git commit -m "Keeping Actions Alive" --allow-empty
+          git push origin actions


### PR DESCRIPTION
GitHub stops Actions if the repository stops getting commits. This adds a GHA that commits to the repo every month.

@steviecoaster will need to run the following commands on a local copy of the repository before December 1st:

```powershell
git switch --orphan actions
git commit --allow-empty -m "Initial commit on orphan branch"
git push -u origin actions
```

Alternatively: you could just create the `actions` branch as a copy of the master branch 🤷‍♂️ 