### PR TITLE
Add Pester tests + CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
-
 on:
   push:
-    branches:
-      - master
+    branches: [ $default-branch ]
+  pull_request:
   workflow_dispatch:
+  workflow_call:
+
+permissions:
+  checks: write
+  pull-requests: write
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  test:
+    name: Pester Tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Pester is installed by default
+      - name: Run Pester Tests
+        run: Invoke-Pester -Path .\tests -OutputFile .\testresults.xml -OutputFormat NUnitXml
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unit Test Results
+          path: ./tests/out/testResults.xml
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: test
+    runs-on: ubuntu-latest
+    # the test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: artifacts/**/*.xml

--- a/tests/Meta.tests.ps1
+++ b/tests/Meta.tests.ps1
@@ -1,0 +1,50 @@
+BeforeAll {
+
+  Set-StrictMode -Version latest
+
+  # Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
+  Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Verbose:$false -Force
+
+  $projectRoot = $ENV:BHProjectPath
+  if (-not $projectRoot) {
+    $projectRoot = $PSScriptRoot
+  }
+
+  $allTextFiles = Get-TextFilesList $projectRoot
+  $unicodeFilesCount = 0
+  $totalTabsCount = 0
+  foreach ($textFile in $allTextFiles) {
+    if (Test-FileUnicode $textFile) {
+      $unicodeFilesCount++
+      Write-Warning (
+        "File $($textFile.FullName) contains 0x00 bytes." +
+        " It probably uses Unicode/UTF-16 and needs to be converted to UTF-8." +
+        " Use Fixer 'Get-UnicodeFilesList `$pwd | ConvertTo-UTF8'."
+      )
+    }
+    $unicodeFilesCount | Should -Be 0
+
+    $fileName = $textFile.FullName
+      (Get-Content $fileName -Raw) | Select-String "`t" | ForEach-Object {
+      Write-Warning (
+        "There are tabs in $fileName." +
+        " Use Fixer 'Get-TextFilesList `$pwd | ConvertTo-SpaceIndentation'."
+      )
+      $totalTabsCount++
+    }
+  }
+}
+
+Describe 'Text files formatting' {
+  Context 'File encoding' {
+    It "No text file uses Unicode/UTF-16 encoding" {
+      $unicodeFilesCount | Should -Be 0
+    }
+  }
+
+  Context 'Indentations' {
+    It "No text file use tabs for indentations" {
+      $totalTabsCount | Should -Be 0
+    }
+  }
+}

--- a/tests/MetaFixers.psm1
+++ b/tests/MetaFixers.psm1
@@ -1,0 +1,80 @@
+# Taken with love from https://github.com/PowerShell/DscResource.Tests/blob/master/MetaFixers.psm1
+
+<#
+    This module helps fix problems, found by Meta.Tests.ps1
+#>
+
+$ErrorActionPreference = 'stop'
+Set-StrictMode -Version latest
+
+function ConvertTo-UTF8() {
+  [CmdletBinding()]
+  [OutputType([void])]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [System.IO.FileInfo]$FileInfo
+  )
+
+  process {
+    $content = Get-Content -Raw -Encoding Unicode -Path $FileInfo.FullName
+    [System.IO.File]::WriteAllText($FileInfo.FullName, $content, [System.Text.Encoding]::UTF8)
+  }
+}
+
+function ConvertTo-SpaceIndentation() {
+  [CmdletBinding()]
+  [OutputType([void])]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [IO.FileInfo]$FileInfo
+  )
+
+  process {
+    $content = (Get-Content -Raw -Path $FileInfo.FullName) -replace "`t", '    '
+    [IO.File]::WriteAllText($FileInfo.FullName, $content)
+  }
+}
+
+function Get-TextFilesList {
+  [CmdletBinding()]
+  [OutputType([IO.FileInfo])]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [string]$Root
+  )
+
+  begin {
+    $txtFileExtentions = @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof')
+  }
+
+  process {
+    Get-ChildItem -Path $Root -File -Recurse |
+      Where-Object { $_.Extension -in $txtFileExtentions }
+  }
+}
+
+function Test-FileUnicode {
+  [CmdletBinding()]
+  [OutputType([bool])]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [IO.FileInfo]$FileInfo
+  )
+
+  process {
+    $bytes = [IO.File]::ReadAllBytes($FileInfo.FullName)
+    $zeroBytes = @($bytes -eq 0)
+    return [bool]$zeroBytes.Length
+  }
+}
+
+function Get-UnicodeFilesList() {
+  [CmdletBinding()]
+  [OutputType([IO.FileInfo])]
+  param(
+    [Parameter(Mandatory)]
+    [string]$Root
+  )
+
+  $root | Get-TextFilesList | Where-Object { Test-FileUnicode $_ }
+}

--- a/tests/Nuspec.Tests.ps1
+++ b/tests/Nuspec.Tests.ps1
@@ -1,0 +1,35 @@
+BeforeDiscovery {
+  $script:specs = Get-ChildItem -Path $PSScriptRoot\..\ -Recurse -Filter "*.nuspec"
+}
+BeforeAll {
+  Import-Module -Name $PSScriptRoot\MetaFixers.psm1
+}
+Describe 'Nuspec File <_.Name>' -ForEach $script:specs {
+  # Validate that the encoding is correct
+  Context 'File encoding' {
+    It "No nuspec file uses Unicode/UTF-16 encoding" {
+      $_ | Test-FileUnicode | Should -Be $false
+    }
+  }
+
+  # Validate that the file is well-formed XML
+  Context 'XML' {
+    BeforeAll {
+      $script:xml = [xml](Get-Content -Path $_.FullName)
+    }
+    It "Nuspec file is well-formed XML" {
+      
+      $script:xml | Should -Not -BeNullOrEmpty
+    }
+
+    # Make sure id matches the xml id
+    It "Nuspec file id matches the xml id" {
+      $filename = $_.BaseName.ToLower()
+      $xml.package.metadata.id | Should -Be $filename
+    }
+
+    It 'ID should be lower case' {
+      $xml.package.metadata.id | Should -Be $xml.package.metadata.id.ToLower()
+    }
+  }
+}

--- a/tests/UpdateFiles.tests.ps1
+++ b/tests/UpdateFiles.tests.ps1
@@ -1,0 +1,41 @@
+BeforeDiscovery {
+  $script:packages = Get-ChildItem -Path $PSScriptRoot\..\automatic -Directory
+}
+Describe 'Update File <_.Name>' -ForEach $script:packages {
+  BeforeAll {
+    $script:UpdateFile = Join-Path -Path $_.FullName -ChildPath 'Update.ps1'
+    $Tokens = $null
+    $Errors = $null
+    $script:ast = [System.Management.Automation.Language.Parser]::ParseFile(
+      $script:UpdateFile,
+      [ref]$Tokens,
+      [ref]$Errors
+    )
+  }
+
+  It 'Update file exists' {
+    $script:UpdateFile | Should -Exist
+  }
+
+  Context 'File encoding' {
+    It "No update file uses Unicode/UTF-16 encoding" {
+      $script:UpdateFile | Test-FileUnicode | Should -Be $false
+    }
+  }
+  
+  It "Import Chocolatey-AU module" {
+    Get-Content $script:UpdateFile | Select-String -Pattern 'Import-Module Chocolatey-AU'
+  }
+
+  It 'has function au_GetLatest' {
+    $functions = $script:ast.FindAll(
+      {
+        param($Ast)
+        $Ast -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $Ast.Name -eq 'global:au_GetLatest'
+      },
+      $false
+    )
+    $functions | Should -HaveCount 1
+  }
+}

--- a/tests/UpdateFiles.tests.ps1
+++ b/tests/UpdateFiles.tests.ps1
@@ -28,14 +28,24 @@ Describe 'Update File <_.Name>' -ForEach $script:packages {
   }
 
   It 'has function au_GetLatest' {
-    $functions = $script:ast.FindAll(
+    $script:ast.FindAll(
       {
         param($Ast)
         $Ast -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
         $Ast.Name -eq 'global:au_GetLatest'
       },
       $false
-    )
-    $functions | Should -HaveCount 1
+    ) | Should -Not -BeNullOrEmpty
+  }
+
+  It 'calls the update function' {
+    $script:ast.FindAll(
+      {
+        param($Ast)
+        $Ast -is [System.Management.Automation.Language.CommandAst] -and
+        $Ast.CommandElements[0].Value -eq 'update'
+      },
+      $false
+    ) | Should -Not -BeNullOrEmpty
   }
 }


### PR DESCRIPTION
1. Add tests
   - Meta tests to verify files are in UTF8
   - Nuspec tests to make sure nuspec files are properly encoded and meet criteria.
   - Add update.ps1 tests
      - Check that the package has an Update.ps1
      - Check that it contains an Import-Module Chocolatey-AU
      - Ensures that an au_GetLatest function is defined
2. Add a github workflow to run the tests on PR and Push.